### PR TITLE
Funksjonelle endringer på sletting av aktive meldinger

### DIFF
--- a/content/guides/integrasjon/sluttbrukere/webservice/endepunkter-oversikt/_index.md
+++ b/content/guides/integrasjon/sluttbrukere/webservice/endepunkter-oversikt/_index.md
@@ -13,9 +13,12 @@ Web servicene beskrevet i dokumentet er angitt uten informasjon om endepunkt. En
 
 Det tilbys opp til tre forskjellige endepunkter for hver web service operasjon:
 
-- Basic Http (SOAP 1.1) - Tradisjonell interoperabel web service
-- WS Http (SOAP 1.2 med WS-Security username token) - Støtte for nye web service standarder WS\*
-- WS Http (SOAP 1.2 med WS-Security X.509 token) (markert som EC) - Støtte for ny web standarder WS\*, dvs. bl.a. at sertifikat ligger i SOAP headeren mens brukernavn og passord ligger i meldingen.
+- **Basic Http (SOAP 1.1)**  
+Tradisjonell interoperabel web service. System og bruker informasjon angis som parameter til operasjoner. Altså i body av SOAP requesten.
+- **WS Http (SOAP 1.2 med WS-Security username token)**  
+Støtte for nye web service standarder WS\*
+- **WS Http (SOAP 1.2 med WS-Security X.509 token) (markert som EC)**  
+Støtte for ny web standarder WS\*, dvs. bl.a. at sertifikat ligger i SOAP headeren. I tillegg krever Altinn et brukernavn og passord som parameter til operasjoner. Dette blir med som en del av body i SOAP requesten.
 
 For eksempel:
 
@@ -25,8 +28,9 @@ Hvis man ønsker å bruke/autentisere vha. WS\* standarden, eller kalle endepunk
 
 Nedenfor følger en oversikt over alle Altinn tjenester, og en aliasoversikt som viser kobling mellom endepunkter, endepunkt operasjon og basis operasjon (operasjon som kalles av endepunktoperasjon, og som er beskrevet i dette dokumentet). Den vil også angi nyeste versjon for operasjonen for endepunktet:
 
-| ReporteeArchiveExternal   |             |     |
+|          |             |     |
 |---------------------------|--------------|--------------|
+| **ReporteeArchiveExternal**   |             |     |
 | **Basis operasjon**           | **URI/Endepunkt**  | **Endepunkt operasjon**  |
 | GetArchivedFormTaskV2     | WS Http  <https://www.altinn.no/ArchiveExternal/ReporteeArchiveExternal.svc>                 | GetArchivedFormTaskExternalV2     |
 |                           | Basic Http  <https://www.altinn.no/ArchiveExternal/ReporteeArchiveExternalBasic.svc>         | GetArchivedFormTaskBasicV2        |

--- a/content/guides/integrasjon/sluttbrukere/webservice/funksjonelle-scenario/_index.md
+++ b/content/guides/integrasjon/sluttbrukere/webservice/funksjonelle-scenario/_index.md
@@ -381,9 +381,11 @@ For noen meldingstjenester krever tjenesteeier at bruker bekrefter at meldingen 
 Slett melding
 ----------------
 
-Et sluttbrukersystem kan velge å slette en melding som er mottatt. Når en meldingstjeneste er slettet vil den ikke være tilgjengelig for verken sluttbruker eller sluttbrukersystem.
+Grensesnittet for meldingstjenester har støtte for å slette aktive (ikke arkiverte) meldinger. Den autentiserte brukeren må ha skrivetilgang til elementet som ønskes slettet. Det er to former for sletting i Altinn. Det er permanent sletting og flytting av element til papirkurv. Sletteoperasjonen vil utføre permanent sletting hvis avgiver er en person. Hvis avgiver er en organisasjon vil elementet bli flyttet til papirkurv.
 
-Når en melding slettes vil det også sendes en lesevarsling til tjenesteeier dersom de har bedt om dette.
+Permanent slettede elementer vil ikke kunne gjennopprettes. Elementet blir helt borte. Elementer som flyttes til papirkurv vil kunne gjennopprettes i sluttbrukerportalen. Det er foreløpig ikke laget noe funksjonalitet for gjennoppretting over SOAP grensesnittet.
+
+Hvis meldingen ikke har vært lest ved slettetidspunktet vil det likevel kunne sendes en lesevarsling til tjenesteeier. Tjenesteeier får på denne måten en indikasjon på at sluttbruker har tatt stilling til meldingen. Er det ønskelig å hindre bruker i å slette uleste meldinger må dette implementeres i sluttbrukerapplikasjonen.
 
 **Tjenester og tjenesteoperasjoner som inngår i beskrevet funksjonalitet:**
 

--- a/content/guides/integrasjon/sluttbrukere/webservice/grensesnitt/_index.md
+++ b/content/guides/integrasjon/sluttbrukere/webservice/grensesnitt/_index.md
@@ -658,7 +658,7 @@ Tabellen under gir en nærmere beskrivelse av objektene som inngår i datakontra
 Correspondence.DeleteCorrespondence
 ----------------
 
-Denne operasjonen kan benyttes av sluttbrukersystemer for å slette en melding i Altinn. Det er kun meldinger for privatpersoner som kan slettes.
+Denne operasjonen kan benyttes av sluttbrukersystemer for å slette en aktiv melding i Altinn.
 
 Tabellen under beskriver datakontrakten for operasjonen.
 
@@ -669,7 +669,10 @@ Tabellen under beskriver datakontrakten for operasjonen.
 | userPinCode       | Pinkode for valgt engangskodetype (authMethod)   |
 | authMethod        | Angir hvilken engangskodetype bruker (i sluttbrukersystemet) vil autentiseres med. Gyldige typer for denne verdien er:  AltinnPin, SMSPin |
 | reporteeElementID | Unik identifikator for en melding i Altinn    |
-| Returverdi        | Beskrivelse               |
+
+
+| Returverdi        | Beskrivelse   |
+|-------------------|---------------|
 | N/A               | Returnerer ingenting hvis alt er OK    |
 
 Correspondence.SaveCorrespondenceConfirmation


### PR DESCRIPTION
Sletting av melding hvor avgiver er en organisasjon benytter papirkurv. Pluss litt finpussing på småting. Relatert til user story 14388 for release 18.1.