### PR TITLE
Basic improvements to the authorization guide for service owner

### DIFF
--- a/content/guides/autorisasjon/_index.md
+++ b/content/guides/autorisasjon/_index.md
@@ -6,79 +6,70 @@ aliases:
  - /guides/lenketjenester/
 ---
 
-## 1 Innledning
+## Innledning
+Implementasjonsguiden for autorisasjon gir en teknisk beskrivelse av hvordan autorisasjon og tilgangskontroll for eksterne tjenester skal implementeres. Dokumentasjonen er ment for utviklingsressurser hos tjenesteeiere som skal utnytte Altinn til autorisasjon og tilgangskontroll. For å beskytte sine tjenester er det også nødvendig at tjenesteeiere etablerer føderering av brukere fra ID-porten. Dette dokumentet inneholder ikke detaljert informasjon om oppsett av føderering mot ID-porten, men beskriver hvordan løsningen for autorisasjon i Altinn forholder seg til ID-porten, og hva dette innebærer for tjenesteeieren.
 
-Implementasjonsguiden for autorisasjon gir en teknisk beskrivelse av hvordan autorisasjon og tilgangskontrollfor eksterne tjenester skal implementeres. Dokumentasjonen er ment for utviklingsressurser hos tjenesteeiere som skal utnytte Altinn til autorisasjon og tilgangskontroll.
-For å beskytte sine tjenester er det også nødvendig at tjenesteeiere etablerer føderering av brukere fra IDPorten. Dette dokumentet inneholder ikke detaljert informasjon om oppsett av føderering mot IDPorten, men beskriver hvordan løsningen for autorisasjon i Altinn forholder seg til IDPorten, og hva dette innebærer for tjenesteeieren.
+[Begrepsdefinisjoner](../definisjoner)
 
-## [**2 Definisjoner**](../../definisjoner)
+## Overordnet flyt for implementasjon av autorisasjon
+Altinn kan benyttes av tjenesteeiere som ønsker å tilgjengeliggjøre informasjon og tjenester på egen plattform og nettsted, men ikke kan utføre en full autorisasjon av brukers tilganger. Roller og rettigheter kan være basert på mye informasjon som hver enkelt tjenesteeier ikke nødvedigvis har tilgang til. For å oppnå dette kan tjenesteeieren opprette en tjeneste av typen lenketjeneste i TUL. Tjenesten migreres til SBL på linje med andre tjeneste¬typer, slik at Altinn kan avgjøre om den aktuelle brukeren har nødvendig tilganger basert på de regler tjenesteeier har definert i TUL.
 
-## 3 Refererte dokumenter og linker
+Altinn leverer autorisasjonstjenester mens ID-porten leverer tjenester for føderering av brukere (Single Sign On).
 
-| Dokument | Beskrivelse |
-|--------|--------|
-| Implementasjonsguide for integrasjon mot Altinn.doc | Dette dokumentet beskriver den overordnede arkitekturen for integrasjon mot Altinn, samt sikkerhetsmekanismer som benyttes for kommunikasjon mellom Altinn og eksterne systemer. |
-| Altinns selvbetjeningsportal |[https://selvbetjening.brreg.no/src/secure/main.jsp#services/home](https://selvbetjening.brreg.no/src/secure/main.jsp#services/home) |
+I forbindelse med autorisasjon i Altinn er det dermed tre aktører:
 
-## 4	Overordnet flyt for implementasjon av autorisasjon
-Altinn kan benyttes av tjenesteeiere som ønsker å tilgjengeliggjøre ta i bruk Altinns autorisasjonskompontent (til tilgangsstyring, autorisasjon og tilgangskontroll), men ønsker å beholde egen tjenestemotor og ha tjenesten på eget nettsted. For å oppnå dette kan tjenesteeieren opprette en tjeneste av typen leenketjeneste i TUL. Tjenesten migreres til SBL på linje med andre tjeneste¬typer, slik at avgiver- og rettighetskrav kan konfigureres i TUL og lenketjenester kan knyttes inn i samhandlingstjenester.
-
-Altinn leverer autorisasjonstjenester mens IDPorten leverer tjenester for føderering av brukere (Single Sign On).
-
-I forbindelse med autoriasjon i Altinn er det dermed tre aktører:
-
-1. IDPorten, som er Identity Provider og foretar autentisering av sluttbruker
+1. ID-porten, som er Identity Provider og foretar autentisering av sluttbruker
 2. Altinn, som foretar autorisasjonskontroll, (og ved bruk av lenking - tjenestekontroller og videreføring av sluttbruker til tjeneste i ekstern portal).
 3. Tjenesteeier for ekstern tjeneste som tilbyr tjenesten til sluttbruker.
 
-**Flyt ved bruk av viderføring i Altinn** 
+### Flyt ved bruk av viderføring i Altinn
 
 {{<figure src="autentisering.jpg" title="Figur 1 – Flyt for lenketjeneste - autentisering" >}}
 
-Figur 1 viser IDPorten, Altinn, tjenesten og tjenesteeier i et standard «SAML-univers». Altinn er ikke Identity Provider og IDPorten utfører dermed all autentisering av sluttbrukere som deretter fødereres mot Altinn som er Service Provider. Altinn deltar i IDPortens Circle of trust sammen med tjenesteeiere for lenketjenester som også er Service Provider.
+Figur 1 viser ID-porten, Altinn, tjenesten og tjenesteeier i et standard «SAML-univers». Altinn er ikke Identity Provider og ID-porten utfører dermed all autentisering av sluttbrukere som deretter fødereres mot Altinn som er Service Provider. Altinn deltar i ID-portens Circle of trust sammen med tjenesteeiere for lenketjenester som også er Service Provider.
 
 - **Punkt 1a og 1b**. Sluttbruker når lenketjenesten på to måter; via tjenestekatalogen i Altinn eller via dyplenke hos tjenenesteeier.
-- **Punkt 2**. Når sluttbruker prøver å nå lenketjenesten i Altinn blir det sjekket om sluttbruker er pålogget Altinn. Dersom sluttbruker ikke er pålogget Altinn, blir brukeren ført til IDPorten for autentisering. Sluttbruker blir autentisert i IDPorten og IDPorten fødererer sluttbrukerens identitet til Altinn.
+- **Punkt 2**. Når sluttbruker prøver å nå lenketjenesten i Altinn blir det sjekket om sluttbruker er pålogget Altinn. Dersom sluttbruker ikke er pålogget Altinn, blir brukeren ført til ID-porten for autentisering. Sluttbruker blir autentisert i ID-porten og ID-porten fødererer sluttbrukerens identitet til Altinn.
 
 {{<figure src="valg-av-avgiver.jpg" title="Figur 2 – Flyt for lenketjenesten – Valg av avgiver og tjenestekontroll" >}}
 
-Altinn har verifisert sluttbrukerens identitet og sluttbrukeren er innenfor Circle of Trust med IDPorten og Altinn. Circle of Trust er et begrept innenfor SAML som beskriver systemer med gjensidig tillitt.
+Altinn har verifisert sluttbrukerens identitet og sluttbrukeren er innenfor Circle of Trust med ID-porten og Altinn. Circle of Trust er et begrept innenfor SAML som beskriver systemer med gjensidig tillitt.
 
  - **Punkt 3. og Punkt 4**. Sluttbrukeren blir ført til valg av avgiver siden i Altinn. Avgiverkontroll og eventuelle tjenestekontroller som er satt på lenketjenesten i TUL blir utført.  
  - **Punkt 5**. Dersom sluttbruker og valgt avgiver tilfredstiller kontrollene satt på tjenesten, blir brukeren videreført til den eksterne tjenesten med en temporær nøkkel lagt til URL.
 
 {{<figure src="autorisasjonskontroll.jpg" title="Figur 3 - Flyt for lenketjenesten - Autorisasjonskontroll" >}}
 
-Tjenesteeier har verifisert at sluttbrukeren er autentisert og sluttbruker er innenfor Circle of Trust med IDPorten, Altinn og Tjenesteeier.
+Tjenesteeier har verifisert at sluttbrukeren er autentisert og sluttbruker er innenfor Circle of Trust med ID-porten, Altinn og Tjenesteeier.
 
- - **Punkt 6**. Når sluttbruker kommer til den beskyttede tjenesten hos tjenesteeier, må tjenesteeier sjekke om sluttbrukeren er pålogget i tjenesteeiers løsning. Dersom sluttbrukeren ikke er pålogget i tjenesteeiers løsning, verifiseres det at brukeren er pålogget i IDPorten og IDPorten fødererer sluttbrukerens identitet til tjenesteeier.
+ - **Punkt 6**. Når sluttbruker kommer til den beskyttede tjenesten hos tjenesteeier, må tjenesteeier sjekke om sluttbrukeren er pålogget i tjenesteeiers løsning. Dersom sluttbrukeren ikke er pålogget i tjenesteeiers løsning, verifiseres det at brukeren er pålogget i ID-porten og ID-porten fødererer sluttbrukerens identitet til tjenesteeier.
  - **Punkt 7**. Tjenesteeier bruker den temporære nøkkelen lagt på URL (tempkey) i webservicekall mot Altinn og henter avgiver valgt av sluttbruker i Altinn.
  - **Punkt 8**. Tjenesteeier sender XACML request i webservicekall til Altinn for å få bekreftet at sluttbruker har rettigheter til å utføre spesifisert operasjon på lenketjenesten til tjenesteeieren for valgt avgiver.
  - **Punkt 9**. Brukeren kan nå lenketjenesten.
 
-## 5 Implementasjon av lenketjenesten.
+## Implementasjon av lenketjenesten.
 
 De påfølgende kapitlene vil gi en teknisk detaljert beskriveles av hvordan tjenesteiere bør implementere lenketjenesten i tjenesteeieres applikasjon.
 
-## 5.1 Utvikling av tjenesteiers eksterne tjeneste
+### Utvikling av tjenesteiers eksterne tjeneste
 
 Hvordan tjenesten skal fungere i ekstern portal har Altinn ikke et forhold til, og tjenesteier har selv ansvaret for utviklingen av applikasjonen som driver den eksterne tjenesten.
 Men, i forhold til lenketjenesten i Altinn er det tre hovedfunksjoner tjenesteier må implementere i sin løsning.
 
-### Føderering av identitet fra IDPorten
-Ressursene som inngår i tjenesten, og dermed er tilgjengelige for sluttbrukere, må beskyttes ved bruk av SAML for føderering av brukerindentiet fra IDPorten. Hvordan dette løses kan tjenesteier selv avgjøre innen for de kravene som stilles av IDPorten. Det som er viktig for lenketjenesten er at sluttbrukers identitet blir verifisert og mottatt i applikasjonen.
+#### Føderering av identitet fra ID-porten
+Ressursene som inngår i tjenesten, og dermed er tilgjengelige for sluttbrukere, må beskyttes ved bruk av SAML for føderering av brukerindentiet fra ID-porten. Hvordan dette løses kan tjenesteier selv avgjøre innen for de kravene som stilles av ID-porten. Det som er viktig for lenketjenesten er at sluttbrukers identitet blir verifisert og mottatt i applikasjonen.
 
-### Hente avgiver med tempkey fra Altinn.
-Når sluttbrukeren overføres fra Altinn til den eksterne tjenesten i en http GET request blir en temporær nøkkel (tempkey) lagt til URL. Denne temporære nøkkelen skal benyttes i webservicekall til Altinn for å hente avgiveren brukeren har valgt i portalen. Det er altså viktig at den temporære nøkkelen kan videreføres igjennom fødereringen mot IDPorten, og dermed kan det være hensiktsmessig at applikasjonen mellomlagrer den temporære nøkkelen før sluttbrukeren blir «redirected» til IDPorten i forbindelse med føderering.
+#### Hente avgiver med tempkey fra Altinn.
+Når sluttbrukeren overføres fra Altinn til den eksterne tjenesten i en http GET request blir en temporær nøkkel (tempkey) lagt til URL. Denne temporære nøkkelen skal benyttes i webservicekall til Altinn for å hente avgiveren brukeren har valgt i portalen. Det er altså viktig at den temporære nøkkelen kan videreføres igjennom fødereringen mot ID-porten, og dermed kan det være hensiktsmessig at applikasjonen mellomlagrer den temporære nøkkelen før sluttbrukeren blir «redirected» til ID-porten i forbindelse med føderering.
 
-### Sjekke sluttbrukers autorisasjon ved bruk av webservice
-Når identiteten til sluttbrukeren er fastslått etter fødereringen fra IDporten, og avgiver er mottatt i responsen fra Altinns webservice, må applikasjonen benytte Altinns autorisasjonswebservice for å få bekreftet at sluttbruker har rettigheter til å utføre spesifisert operasjon på lenketjenesten til tjenesteeieren for valgt avgiver.
+#### Sjekke sluttbrukers autorisasjon ved bruk av webservice
+Når identiteten til sluttbrukeren er fastslått etter fødereringen fra ID-porten, og avgiver er mottatt i responsen fra Altinns webservice, må applikasjonen benytte Altinns autorisasjonswebservice for å få bekreftet at sluttbruker har rettigheter til å utføre spesifisert operasjon på lenketjenesten til tjenesteeieren for valgt avgiver.
  
-## 5.2 Integrasjon mot IDPorten
+### Integrasjon mot ID-porten
 ID-Porten er Identity Provider for lenketjenester, og tjenesteeiere i Altinn som har lenketjenester må etablere en egen, standard, samarbeidsavtale med ID-porten. Dette fordi en slik tjenesteeier vil måtte ha en direkte integrasjon mot ID-porten.
-DIFI har utarbeidet en tilslutningsguide som beskriver den jobben som må gjøres for å sette opp SAML-integrasjon mot IDPorten. Tilslutningsguiden finnes under ID-Porten > Dokumentasjon i [Samarbeidsportalen] (http://samarbeid.difi.no) til Difi.
+DIFI har utarbeidet en tilslutningsguide som beskriver den jobben som må gjøres for å sette opp SAML-integrasjon mot ID-porten. Tilslutningsguiden finnes under ID-Porten > Dokumentasjon i [Samarbeidsportalen] (http://samarbeid.difi.no) til Difi.
 
-## 5.3 Utvikle Lenketjenesten i TUL 
+### Utvikle Lenketjenesten i TUL 
 Lenketjenestene utvikles i TUL på samme måte som andre tjenestetyper, ved at man først oppretter en tjeneste med tjenestetype Lenketjeneste, og deretter har utgaver av tjenesten på nivået under. Det er utgavene som migreres til SBL og er tilgjengelig for sluttbruker. Når tjenesten opprettes blir det generert en ekstern tjenestekode, som er unik for hver enkelt tjeneste. Sammen med ekstern utgavekode, som man setter på Utgaveparametre, danner ekstern tjenestekode en unik identifikator til hver utgave. Ekstern tjenestekode og ekstern utgavekode brukes både i direktelenke til tjenesten i Altinn, samt i autorisasjonsforespørselen mot Altinn.
 
 Det som skiller lenketjenestene fra andre tjenestetyper er at det på lenketjenestene legges inn en URL til tjenesten på tjenesteeiers side i utgavespesifikasjonen, og siden test-URL og prod-URL er forskjellig, må man derfor alltid opprette en test-utgave og en prod-utgave.
@@ -108,11 +99,11 @@ Tilgjengelige valg er:
 -	Person eller juridisk enhet
 -	Bedrift, juridisk enhet eller konkursbo
 -	Alle aktører
--	Sikkerhetsnivå – lenketjenester i Altinn 2 må settes opp med sikkerhetsnivå 3 eller 4, fordi IDPorten benyttes til autentisering og de tilbyr nivå 3 og 4.
+-	Sikkerhetsnivå – lenketjenester i Altinn 2 må settes opp med sikkerhetsnivå 3 eller 4, fordi ID-porten benyttes til autentisering og de tilbyr nivå 3 og 4.
 -	Virksomhetsbrukere – angi om sluttbrukere skal kunne bruke virksomhetssertifikat til å logge inn. Med virksomhetssertifikat er det ingen knytning til fødselsnummeret til vedkommende som bruker tjenesten.
 -	Samhandlingstjeneste – lenketjenester kan defineres til å kunne inngå i en samhandlingstjeneste. Da settes det et kryss på utgaven her, og utgaven vil være valgbar som tilgjengelig tjeneste for samhandlingstjenester.
 
-### Altinn rolle
+#### Altinn rolle
 På samme måte som andre tjenestetyper, må lenketjenestene knyttes til en eller flere Altinn-roller slik at tjenestene blir tilgjengelig for sluttbrukerne.
 Altinn-rollene er knyttet til et sett med eksterne roller fra Enhetsregisteret (ER), og når tjenesteeier skal velge
 hvilke(n) Altinn-rolle(r) som skal gi tilgang til tjenesten,er det viktig å tenke over en del ting:
@@ -120,7 +111,7 @@ hvilke(n) Altinn-rolle(r) som skal gi tilgang til tjenesten,er det viktig å ten
 -	Hvem skal bruke tjenesten – det må velges en eller flere roller som sikrer at alle aktuelle avgivere har tilgang til tjenesten. Ulike organisasjonstyper registrerer ulike typer eksterne roller i ER, og tjenesteeier må velge en Altinn-rolle som dekker ulike organisasjonstyper. F.eks vil et enkeltpersonsforetak kanskje bare ha innehaver registrert, mens et AS har både daglig leder, styreleder og revisor. Hvis både ENK’et og AS’et skal kunne benytte tjenesten, må Altinn-rollen som knyttes til tjenesten være knyttet til både Innehaver og Daglig leder, Styreleder eller Revisor. Tilgjengelige roller finnes på "rolleadministrasjonssiden" i TUL og i [portalhjelpen](https://www.altinn.no/no/Portalhjelp/Administrere-rettigheter-og-prosessteg/Rolleoversikt) i SBL.
 -	Skal ulike roller har tilgang til å utføre ulike operasjoner på tjenesten? Dette kan man skille på i rolletilknytningen. Vær i midlertid oppmerksom på at Altinn kun sjekker at man har lese-tilgang til tjenesten ved instansiering. Hvis man ønsker en mer detaljert autorisasjonssjekk, må dette implementeres i tjenesteeiers tjeneste-applikasjon.
 
-## 5.4 Bruk av Altinns autorisasjonswebservice
+### Bruk av Altinns autorisasjonswebservice
 
 Altinns webservice for autorisasjon kan benyttes av tjenesteiere til å foreta autorisasjonsbeslutninger basert på rolle og rettighetsregler og delegeringer som ligger i Altinns autorisasjonsdatabase. Dette gjør at eksterne tjenester som ikke benytter Altinns tjenestemotor likevel kan benytte Altinns autorisasjonsmodell på tjenesten. For lenketjenester, for eksempel en tjeneste hvor avgiver kan være en organisasjon, er dette sentralt.
 
@@ -152,7 +143,7 @@ Disse tabellene viser endepunktene og operasjonene for Altinns to webservices fo
 | SSN | Fødselsnummer for denne avgiveren hvis dette er en person. |
 | Reportee Type | Typebeskrivelse for hvilken type avgiver dette er: None, Person, Organization, eller SelfIdentified (ikke et praktisk mulig scenario i denne sammenhengen). |
 
-### Eksempel Request
+#### Eksempel Request
 
 ```xml
 <?xml version="1.0"?>
@@ -168,7 +159,7 @@ Disse tabellene viser endepunktene og operasjonene for Altinns to webservices fo
 
 {{%attachments title="XML SOAP request" pattern="getReporteeByTempKeyReq.xml"/%}}
 
-### Eksempel Response
+#### Eksempel Response
 
 ```xml
 <s:Envelope xmlns:s="http://www.w3.org/2003/05/soap-envelope" xmlns:a="http://www.w3.org/2005/08/addressing" xmlns:u="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd">
@@ -198,9 +189,9 @@ Disse tabellene viser endepunktene og operasjonene for Altinns to webservices fo
 Dersom nøkkelen er ugyldig (for eksempel, på grunn av timeout, eller tidligere bruk) vil operasjonen returnere en Altinnfault. Den eksterne tjenesten bør da presentere en feilmelding for sluttbruker, og gi sluttbruker mulighet til å gå tilbake til Altinn (dyplenken til tjenesten) for å starte tjenesten på ny.
 
 
-### 5.4.2	AuthorizationDecisionPointExternal.AuthorizeAccessExternal
+### AuthorizationDecisionPointExternal.AuthorizeAccessExternal
 
-Når applikasjonen som driver den eksterne tjenesten har verifisert identiten til brukeren med føderering fra IDPorten, og mottatt avgiver (valgt av sluttbruker) ved kall til GetReporteeByTempKey, må det verifiseres at sluttbruker har rettighet til å benytte tjenesten for valgt avgiver. Dette gjøres med kall til AuthorizationDecisionPointExternal.AuthorizeAccesExternal.
+Når applikasjonen som driver den eksterne tjenesten har verifisert identiten til brukeren med føderering fra ID-porten, og mottatt avgiver (valgt av sluttbruker) ved kall til GetReporteeByTempKey, må det verifiseres at sluttbruker har rettighet til å benytte tjenesten for valgt avgiver. Dette gjøres med kall til AuthorizationDecisionPointExternal.AuthorizeAccesExternal.
 
 AuthorizeAccessExternal operasjonen benytter XACML standarden og regler lagret i Altinn til å returnere en autorisasjonsbeslutning. Besluttningsgrunnlaget til autorisasjon for tjenester er de regler (rolleknytninger) som tjenesteeier har satt på lenketjenesten i TUL.
 
@@ -226,7 +217,7 @@ XACML-forespørselen skal inneholde **kun et Resource element** med kombinasjon 
 
 Nedenfor vises eksempler på gyldig forespørsler:
 
-####  AuthorizationRequest:
+#### AuthorizationRequest:
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
 <Request
@@ -273,7 +264,7 @@ Nedenfor vises eksempler på gyldig forespørsler:
 </Request>
 ```
 Operasjonen returnerer XML som også følger XACML standarden. Under vises et eksempel på en response.
-####  AuthorizationResponse:
+#### AuthorizationResponse:
 ```xml
 <xacml:Response xmlns:tns="urn:oasis:names:tc:xacml:2.0:policy:schema:os" xmlns:xacml="urn:oasis:names:tc:xacml:2.0:context:schema:os" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="urn:oasis:names:tc:xacml:2.0:context:schema:os http://docs.oasis-open.org/xacml/2.0/access_control-xacml-2.0-context-schema-os.xsd">
   <xacml:Result ResourceId="">
@@ -308,7 +299,7 @@ Uavhengig av valgt metode for å velge avgiver på nytt, må det gjøre et påf�
 **Feilsituasjoner**
 Dersom Altinn ikke klarte å gjøre en korrekt beslutning for parameterne spesifisert i requesten, vil XACML responsen fra Altinn indikerere dette (<xacml:Decision>Indeterminate</xacml:Decision>). Ved annen teknisk feil vil operasjonen returnere en Altinnfault. Den eksterne tjenesten bør da presentere en feilmelding for sluttbruker, og gi sluttbruker mulighet til å gå tilbake til Altinn (dyplenken til tjenesten) for å starte tjenesten på ny.
 
-#### 5.4.3 AuthorizationAdministrationExternal.GetReportees
+#### AuthorizationAdministrationExternal.GetReportees
 
 Metoden GetReportees returnerer alle mulige avgivere for en person (identifisert med fødselsnummer) uavhengig av hvilke roller/rettigheter denne personen har for avgiveren. Dermed må det også ved bruk av denne tjenesten utføres en påfølgende autorisasjonssjekk med XACML webservice mot en lenketjeneste som rollekravene for den eksterne tjenesten kan knyttes til.
 
@@ -410,11 +401,11 @@ I disse tilfellene må sluttbruker informeres om dette, og gis mulighet til å l
 
 Dersom det fødselsnummeret spesifisert er ugyldig vil Altinn returnere en Altinnfault
 
-### 6	Feilsituasjoner i produksjon
+## Feilsituasjoner i produksjon
 
 Dersom det oppdages feil ved bruk av lenketjenesten, er det viktig at det indentifiseres hvor feilen ligger.
-Feil i forbindelse med føderering fra IDPorten skal meldes til IDPorten og ikke til Altinn.
+Feil i forbindelse med føderering fra ID-porten skal meldes til ID-porten og ikke til Altinn.
 
-Dersom lenken til den eksterne tjenesten i Altinn er korrekt, det ikke er feil i forbindelse med føderering fra IDPorten, og tjenesteeier er sikker på at feilen ikke ligger i egen applikasjon bør tjenesteeier kontakte ASF. Feilmelding kan da sendes til tjenesteeier@altinn.no
+Dersom lenken til den eksterne tjenesten i Altinn er korrekt, det ikke er feil i forbindelse med føderering fra ID-porten, og tjenesteeier er sikker på at feilen ikke ligger i egen applikasjon bør tjenesteeier kontakte ASF. Feilmelding kan da sendes til tjenesteeier@altinn.no
 
 Feilmeldingen må inneholde informasjon om tjenesten, tidspunkt for feilen og hvilke brukere og avgivere feilen dreier seg om. SOAP request og response for kall til Altinns autorisasjonswebservices må også vedlegges feilmeldingen.


### PR DESCRIPTION
- Removed chapter numbering
- Changed "IDPorten" to "ID-porten"
- Fixed the link to "Begrepsdefinisjoner"
- Minor improvents to the two first paragraphs
This document still needs a lot of work.