### PR TITLE
Oppdatert eksempel på respons ved henting av melding via REST 

### DIFF
--- a/content/guides/integrasjon/sluttbrukere/api/meldinger/hente.md
+++ b/content/guides/integrasjon/sluttbrukere/api/meldinger/hente.md
@@ -319,8 +319,12 @@ Eksempel respons fra API for message av typen `FormTask`:
         "attachment": [
             {
                 "href": "https://www.altinn.no/api/my/messages/a1507495/attachments/282783",
-                "name": "oppgaver.txt",
-                "encrypted": false
+                "name": "oppgaver",
+                "fileName": "oppgaver.txt",
+                "encrypted": false,
+                "signinglocked": false,
+                "signedbydefault": true,
+                "filesize": 16027
             }
         ]
     }
@@ -357,8 +361,12 @@ Eksempel respons fra API for message av typen `Correspondence`:
         "attachment": [
             {
                 "href": "https://www.altinn.no/api/my/messages/a385571/attachments/187938",
-                "name": "Tiltak_201301840.pdf",
-                "encrypted": false
+                "name": "Tiltak_201301840",
+                "fileName": "Tiltak_201301840.pdf",
+                "encrypted": false,
+                "signinglocked": false,
+                "signedbydefault": true,
+                "filesize": 967038
             }
         ],
         "archivereference": {
@@ -391,8 +399,12 @@ Message-element inneholder en hash tabell `_links` som inneholder lenker til bes
         "attachment": [
             {
                 "href": "https://tt02.altinn.basefarm.net/api/my/messages/a1507495/attachments/282783",
-                "name": "oppgaver.txt",
-                "encrypted": false
+                "name": "oppgaver",
+                "fileName": "oppgaver.txt",
+                "encrypted": false,
+                "signinglocked": false,
+                "signedbydefault": true,
+                "filesize": 16027
             }
         ],
         "form": [


### PR DESCRIPTION
Dette er en endring knyttet til userstory 22154 hvor det var ønske om å sende ved filending som en egen verdi. Denne endringen har oppdatert eksemplet som returneres under _links attachment for en melding. Det ble også inkludert andre parameter som ikke var listet i eksemplet, men som sendes som REST-respons. Endringen med "fileName" kommer inn i release 18.11