### PR TITLE
Revisjon av ROADMAP med leveranse i 18.11

### DIFF
--- a/content/roadmap/_index.md
+++ b/content/roadmap/_index.md
@@ -49,12 +49,15 @@ Denne funksjonen er etablert, men ikke gjort tilgjengelig. En avventer ferdigsti
 Det skal etableres en løsning slik at organisasjoner kan tømme egen papirkurv.  
 Dette ble [levert i release 18.10](/docs/releases/2018/18-10/#brukere-som-representerer-en-organisasjon-kan-n%C3%A5-permanent-slette-elementer-fra-slettede-i-innboksen).
 
-### Endre avsender for SMS-varsel
+### :heavy_check_mark: Endre avsender for SMS-varsel
 Det skal etableres løsning for å kunne endre avsender på
 [frittstående SMS-varsel](/docs/guides/integrasjon/tjenesteeiere/funksjonelle-scenario/#frittst%C3%A5ende-varsel) fra Altinn.
+Dette ble [levert i release 18.11](/docs/releases/2018/18-11/#mulighet-for-tjenesteeier-%C3%A5-st%C3%A5-som-avsender-av-sms-standalone-varslinger).
 
-### Fjerne basisrollen ALLEA i sin helhet
+### :heavy_check_mark: Fjerne basisrollen ALLEA i sin helhet
 Det skal etableres løsning slik at det fremgår tydeligere for bruker hvilke tilganger som deles ved en delegering.
+Dette ble [levert i release 18.11](/docs/releases/2018/18-11/#rydde-opp-i-databasen-rundt-allea).
+
 
 ### Oppdatering av SharePoint og .NET
 SharePoint skal oppdateres til nyere CU, og .NET til siste versjon, i både sluttbrukerløsningen og i tjenesteutviklingsløsningen.  


### PR DESCRIPTION
I versjon 18.11 ble endring av avsender på frittstående SMS varsling og opprydding/fjerning av basisrollen ALLEA levert