### PR TITLE
19.1 Oppdatert samtykke doc for autorisering av tredjepart/HandledBy fra SRR

### DIFF
--- a/content/guides/samtykke/datakilde/bruk-av-token/_index.md
+++ b/content/guides/samtykke/datakilde/bruk-av-token/_index.md
@@ -14,7 +14,8 @@ informasjon knyttet til de delegerte rettighetene inkludert
 * tjenestekoder for lenketjenesten i Altinn
 * fødsels- eller organisasjonsnummer som samtykket
 * tildelte rettigheter til datakonsumenten
-* person- eller organisasjonsnummer for datakonsumenten som fikk rettighetene
+* person- eller organisasjonsnummer for datakonsumenten som har mottatt rettighetene
+* organisasjonsnummer for tredjepart som kan behandle samtykket på vegne av mottaker (dersom dette foreligger)
 * tidspunkt for når samtykke ble gitt
 * tidspunkt for når rettigheten opphører
 
@@ -156,6 +157,13 @@ Eksempel:
 SSN: `"CoveredBy": "02056260016"`
 
 OrgNo: `"CoveredBy": "910514458"`
+
+#### HandledBy
+HandledBy inneholder Organisasjonsnummer for tredjepart som gjennom rettighetsstyring i tjenesteeierstyrt rettighetsregister (SRR) er autorisert til å behandle samtykker på vegne av CoveredBy.    
+Denne vil bare være en del av payload dersom det er tredjepart selv som har hentet signert JWT for å bruke dette for å autorisere seg for datakilden utenfor Altinn.
+
+Eksempel:  
+OrgNo: `"HandledBy": "910459880"`
 
 #### ValidToDate
 Dato og tidspunkt for når samtykket utløper

--- a/content/guides/samtykke/datakonsument/hente-token/_index.md.md
+++ b/content/guides/samtykke/datakonsument/hente-token/_index.md.md
@@ -9,7 +9,7 @@ weight: 30
 
 Autorisasjonskoden som datakonsument mottar fra Altinn når sluttbruker har samtykket benyttes til å hente token. Altinn plattformen støtter at man kan veksle inn autorisasjonskoden via
 REST med ApiKey. Det krever at man har ApiKey som er registrert på
-organisasjonsnummer som matcher mottaker av samtykke. Bestilling av nye nøkler, eller
+organisasjonsnummer som enten matcher mottaker av samtykke eller registrert tredjepart som kan behandle samtykker på vegne av mottaker. Bestilling av nye nøkler, eller
 oppdatering av eksisterende, gjøres ved henvendelse til [servicedesk@altinn.no](mailto:servicedesk@altinn.no).
 
 Tokenet som returneres vil være en streng bestående av et base64-encodet Json Web Token.
@@ -32,7 +32,7 @@ TCiReKcySRcvDtRhLtFVH8zT-VcaEEXyA9_tTUumUVKTqy9vPMDOYAhmih55uT__Ghs5UQbxDZXLJ08f
 L3BvmjYTg_xm69mBRkGuW431fZnMiY_U3Omrd0gHniu8ri33lpEaL3ip1Lq65QC_jVzy2WHN1RdQCA5WiYGJ89GoSZL2eAtCS8d7qngsMUu
 zBPpcn4hDiI7MkK4RWrAc2drTw
 ```
-Hvis datakilde ønsker å verifisere hvilken verdi som ligger i "offeredeBy" (fødsels- eller organisasjonsnummer til den som har gitt samtykke) så må token decodes. Se [her](../../datakilde/bruk-av-token/#bruk-av-self-contained-oauth-token) for eksempel på decoded token samt informasjon om sertifikat som må benyttes ved decoding. 
+Hvis datakilde ønsker å verifisere hvilken verdi som ligger i "offeredBy" (fødsels- eller organisasjonsnummer til den som har gitt samtykke) så må token decodes. Se [her](../../datakilde/bruk-av-token/#bruk-av-self-contained-oauth-token) for eksempel på decoded token samt informasjon om sertifikat som må benyttes ved decoding. 
 
 REST-tjenesten returnerer 403 dersom authcode er ugyldig eller Apikeyen
 ikke har tilgang til angitt autorisasjonskode:

--- a/content/guides/samtykke/datakonsument/logge-bruk/index.md
+++ b/content/guides/samtykke/datakonsument/logge-bruk/index.md
@@ -4,7 +4,7 @@ description: Hvordan logge at man har hentet data som sluttbruker har samtykket 
 weight: 50
 ---
 
-Når man har hentet data som er omfattet av samtykket som sluttbruker har gitt, kan man logge at data er hentet. For å logge bruk av samtykke/henting av data, trenger man autorisasjonskoden som ble gitt når sluttbruker samtykket til deling av data, samt ApiKey som er registrert på organisasjonsnummer som matcher mottaker av samtykke.
+Når man har hentet data som er omfattet av samtykket som sluttbruker har gitt, kan man logge at data er hentet. For å logge bruk av samtykke/henting av data, trenger man autorisasjonskoden som ble gitt når sluttbruker samtykket til deling av data, samt ApiKey som er registrert på enten organisasjonsnummer som matcher mottaker av samtykke eller tredjepart som kan behandle samtykker på vegne av mottaker.
 
 Via REST benyttes POST på https://www.altinn.no/api/authorization/token/{AuthCode}/loguse 
 

--- a/content/guides/samtykke/datakonsument/test-tjeneste/_index.md
+++ b/content/guides/samtykke/datakonsument/test-tjeneste/_index.md
@@ -40,9 +40,9 @@ Se [Informasjon om token](../../datakilde/bruk-av-token/#bruk-av-self-contained-
 
 ### Teste å veksle inn autorisasjonskode i token
 Altinn plattformen støtter at man kan veksle inn autorisasjonskoden via
-REST med ApiKey. Det krever at man har ApiKey som er registrert på
-organisasjonsnummer som matcher mottaker av samtykke. Ingen annen form
-for autentisering er nødvendig. Som nevnt gjøres bestilling av nye
+REST med ApiKey. Det krever at man har ApiKey som er registrert på mottaker av samtykke eller tredjepart som kan behandle samtykker på vegne av mottaker.
+En eventuell tredjepart må være registrert i tjenesteeierstyrt rettighetsregister (SRR).
+Ingen annen form for autentisering er nødvendig. Som nevnt gjøres bestilling av nye
 nøkler, eller oppdatering av eksisterende, ved henvendelse til
 [servicedesk@altinn.no](mailto:servicedesk@altinn.no).
 


### PR DESCRIPTION
Oppdatering for sidene med samtykke dokumentasjon for endringer relatert til US 26097 & 25466.
Disse gjør det nå mulig for registrert tredjepart (HandledBy) i tjenesteeeierstyrt rettighetsregister (SRR) kan opptre på vegne av datakonsument (CoveredBy) og behandle samtykker gitt til datakonsumenten. Dette ved å benytte egen API nøkkel som er registrert på samme organisasjonsnummer som er registrert som HandledBy i SRR.