### PR TITLE
Fixing Source -> .File

### DIFF
--- a/themes/hugo-theme-docdock/layouts/partials/logo.html
+++ b/themes/hugo-theme-docdock/layouts/partials/logo.html
@@ -1,4 +1,4 @@
-{{ range where .Site.Pages "Source.BaseFileName" "_header" }} 
+{{ range where .Site.Pages ".File.BaseFileName" "_header" }} 
 	{{ .Content }} 
 {{else}}
 <span style="font-size:smaller">


### PR DESCRIPTION
Hugo versions ≥ 0.50 uses `.File` over `Source`