### PR TITLE
Added line that refers to the postman-examples repo.

### DIFF
--- a/content/api/rest/kom-i-gang.md
+++ b/content/api/rest/kom-i-gang.md
@@ -284,3 +284,4 @@ for å opprette virksomhetsbruker i portal.
 ## Du er klar! 
 
 Når du har fullført registrering og autentisering er du klar til å kommunisere med Altinn fra web-applikasjonen din! Finn tilgjengelige REST-APIer i venstremenyen. 
+Her er en [Postman collection](https://github.com/Altinn/postman-examples) som inneholder eksempler på REST-spørringene som ligger under https://altinn.no/api/help og https://altinn.no/api/serviceowner/help.


### PR DESCRIPTION
User storyen 38286 gikk ut på å lage en postman collection som inneholder eksempler på REST-kallene fra api/help og api/serviceowner/help. Denne oppdateringen legger til en lenke til det postman-collection-repoet i "komme i gang"-siden i docs.