### PR TITLE
Fix copypaste error, fix link to Swagger

### DIFF
--- a/content/utviklingsguider/sikkerhet-i-eoppslag/_index.md
+++ b/content/utviklingsguider/sikkerhet-i-eoppslag/_index.md
@@ -43,7 +43,7 @@ graph TD
   CON --> |4. Delegerer tilgang til leverandør via Portal|AP
   </div>
 
-Underleverandøren får beskjed om dette via varsel, og kan da opprette en OAuth2-klient i Maskinporten som provisjoneres med scopet som representerer Folkeregisteret. Når underleverandøren da forsøker å hente ut et access token, oppgir de at de gjøre dette på vegne av Brønnøysundregistrene. Maskinporten gjør da et oppslag mot Altinn for å sjekke om det foreligger en aktiv delegering på Folkeregister-scopet gitt fra Brønnøysundregistrene til underleverandøren. Altinn returnerer en bekreftelse på dette, og Maskinporten utsteder token til underleverandører, som da kan bruke dette mot Skatteetatens API som om den var Brønnøysundregistrene.
+Underleverandøren får beskjed om dette via varsel, og kan da opprette en OAuth2-klient i Maskinporten som provisjoneres med scopet som representerer Folkeregisteret. Når underleverandøren da forsøker å hente ut et access token, oppgir de at de gjøre dette på vegne av Leikanger Kommune. Maskinporten gjør da et oppslag mot Altinn for å sjekke om det foreligger en aktiv delegering på Folkeregister-scopet gitt fra Leikanger Kommune til underleverandøren. Altinn returnerer en bekreftelse på dette, og Maskinporten utsteder token til underleverandører, som da kan bruke dette mot Skatteetatens API som om den var Leikanger Kommune.
 
 <div class="mermaid my-4">
 graph TD

--- a/content/utviklingsguider/sikkerhet-i-eoppslag/api-eier.md
+++ b/content/utviklingsguider/sikkerhet-i-eoppslag/api-eier.md
@@ -32,7 +32,7 @@ Les mer om denne prosessen i [dokumentasjonen for Maskinporten](https://samarbei
 
 For å registrere scopes som delegerbare API-ressurser ("delegation schemes") i Altinn kreves en Maskinporten-autentitisering med scopet `altinn:maskinporten/delegationSchemes.write`. Som regel vil en også ha `altinn:maskinporten/delegationSchemes.read` for å kunne administrere sine delegation-schemes.
 
-API-et er dokumentert på https://www.altinn.no/maskinporten-api/ui/swagger/. Under er et eksempel på et delegationScheme:
+API-et er dokumentert på https://www.altinn.no/maskinporten-api/swagger/ui/index. Under er et eksempel på et delegationScheme:
 
 ```
 POST /maskinporten-api/delegationSchemes HTTP/1.1


### PR DESCRIPTION
Stod "Brønnøysundregistrene" i eksemplet der det skulle stått "Leikanger kommune". Har også fikset en 404 til swagger.