### PR TITLE
Remove note about changing environment in dev

### DIFF
--- a/content/altinn-studio/app-creation/konfigurasjon/_index.md
+++ b/content/altinn-studio/app-creation/konfigurasjon/_index.md
@@ -71,8 +71,6 @@ Hver fil skal altså ha verdier som er unike eller anderledes i minst ett annet 
 }
 ```
 
-Det er faktisk mulig å overstyre hvilke miljø man kjører som under lokal utvikling ved å endre verdien til `ASPNETCORE_ENVIRONMENT` i `Properties/launchSettings.json` filen.
-
 ## Miljøvariabler
 
 Standard oppførsel til en ASP.Net applikasjon er å lese inn miljøvariabler. Dette gjøres også for en App, men det er ikke mulig for en Apputvikler å lage eller endre noen verdier per i dag. Altinn 3 mener at denne måten å styre miljøspesifikke verdier på dekkes av appsettings og KeyVault. 


### PR DESCRIPTION
Removing the note about the option to change environment for local development. Changing it to anything other than `Development` will cause an error during startup. The cause being the JwtCookieOptions.RequireHttpsMetadata not being set to false.

This is related to issue [2187 under altinn-studio](https://github.com/Altinn/altinn-studio/issues/2187).