### PR TITLE
Update oppdatere.md

### DIFF
--- a/content/api/rest/meldinger/oppdatere.md
+++ b/content/api/rest/meldinger/oppdatere.md
@@ -95,7 +95,7 @@ Body
 ```
 ### Legge til vedlegg med streaming
 For å legge til større vedlegg til en aktiv skjemainstans kan man bruke en streamingvariant mot attachment der requestbody er en binær strøm.
-Vedleggs-id returneres i location header på responsen.
+Vedleggs-id returneres i location header på responsen. Det er viktig å merke seg at filnavn er et query parameter (fileName) og man må derfor sørge for at dette er URL-enkodet. 
 
 Header
 ```HTTP


### PR DESCRIPTION
La til info som kanskje er en selvfølge, men som vi har sett at brekker kallet til streamingAPIet. P.t. vil feks en # i filnavnet gi en 401 respons, noe som er en helt annen feil (til og med en feil feil), men dog..