### PR TITLE
Moved DAN docs to docs.data.altinn.no

### DIFF
--- a/content/utviklingsguider/data.altinn.no/_index.md
+++ b/content/utviklingsguider/data.altinn.no/_index.md
@@ -10,6 +10,10 @@ aliases:
     - /utviklingsguider/data.altinn.no/ebevis
 ---
 
+<script>
+    window.location.href = 'https://docs.data.altinn.no'
+</script>
+
 
 ## Innledning
 

--- a/content/utviklingsguider/data.altinn.no/api/_index.md
+++ b/content/utviklingsguider/data.altinn.no/api/_index.md
@@ -8,6 +8,10 @@ aliases:
     - /utviklingsguider/data.altinn.no/bruke-rest-api/
 ---
 
+<script>
+    window.location.href = 'https://docs.data.altinn.no/api/'
+</script>
+
 
 ## Innledning
 

--- a/content/utviklingsguider/data.altinn.no/datasett/_index.md
+++ b/content/utviklingsguider/data.altinn.no/datasett/_index.md
@@ -6,6 +6,10 @@ aliases:
 - /utviklingsguider/data.altinn.no/beviskoder/
 ---
 
+<script>
+    window.location.href = 'https://docs.data.altinn.no/datasett/'
+</script>
+
 Denne listen er bygd dynamisk basert på [metadata-API-et til data.altinn.no](https://data.altinn.no/api-details#api=publicmetadata). Du kan velge mellom å se datasettene i test eller prod med å sjekkboksen øverst til høyre. Hvert datasett kan ekspanderes for å vise hvordan datasettet er utformet, og hvilke autorisasjonsregler som ligger til grunn. Her finner du også eksempler på hvordan forespørsler kan utformes.
 
 {{% evidencecodes %}}

--- a/content/utviklingsguider/data.altinn.no/ofte-stilte-spørsmål/_index.md
+++ b/content/utviklingsguider/data.altinn.no/ofte-stilte-spørsmål/_index.md
@@ -4,6 +4,10 @@ linktitle: Spørsmål og svar
 weight: 250
 ---
 
+<script>
+    window.location.href = 'https://docs.data.altinn.no/ofte-stilte-spørsmål/'
+</script>
+
 
 ## Spørsmål og svar
 

--- a/content/utviklingsguider/data.altinn.no/rollekrav-i-altinn/_index.md
+++ b/content/utviklingsguider/data.altinn.no/rollekrav-i-altinn/_index.md
@@ -5,6 +5,10 @@ description: data.altinn.no bruker funksjonalitet i Altinn for å generere samty
 weight: 55
 ---
 
+<script>
+    window.location.href = 'https://docs.data.altinn.no/rollekrav-i-altinn/'
+</script>
+
 ### Altinn
 Alle samtykkeforespørsler fra tjenester på data.altinn.no sendes til Altinn i form av en melding med lenke til det faktiske samtykket. Man trenger derfor flere rettigheter i Altinn - både til melding og samtykke.
 Se [samtykkeprosessen](/docs/utviklingsguider/data.altinn.no/samtykkeprosessen/) for mer informasjon med skjermbilder. 

--- a/content/utviklingsguider/data.altinn.no/samtykkeprosessen/_index.md
+++ b/content/utviklingsguider/data.altinn.no/samtykkeprosessen/_index.md
@@ -4,6 +4,10 @@ description: Når oppdragsgiver initierer en samtykkeforespørsel vil det bli se
 weight: 55
 ---
 
+<script>
+    window.location.href = 'https://docs.data.altinn.no/samtykkeprosessen/'
+</script>
+
 
 Brukeren logger seg inn i Altinn og finner en samtykkelenke i meldingsboksen til mottakers innboks – enten om det er brukeren som privatperson eller for en virksomhet.
 

--- a/content/utviklingsguider/data.altinn.no/testing/_index.md
+++ b/content/utviklingsguider/data.altinn.no/testing/_index.md
@@ -5,6 +5,11 @@ toc: true
 weight: 40
 ---
 
+<script>
+    window.location.href = 'https://docs.data.altinn.no/testing/'
+</script>
+
+
 ## Testmiljø
 
 data.altinn.no har et preproduksjons-miljø kalt "staging" som kan brukes i forbindelse med testing av implementasjoner. Alle endringer som skal i produksjon blir først deployet til staging-miljøet før de produksjonssettes. 

--- a/content/utviklingsguider/data.altinn.no/tjenester/_index.md
+++ b/content/utviklingsguider/data.altinn.no/tjenester/_index.md
@@ -4,6 +4,10 @@ description: Beskrivelse av de forskjellige datadelingstjenestene på data.altin
 weight: 100
 ---
 
+<script>
+    window.location.href = 'https://docs.data.altinn.no/tjenester/'
+</script>
+
 {{% children description="true" %}}
 
 

--- a/content/utviklingsguider/data.altinn.no/tjenester/drosjeloyve/_index.md
+++ b/content/utviklingsguider/data.altinn.no/tjenester/drosjeloyve/_index.md
@@ -4,6 +4,11 @@ description: Innehenting av data i søknadsprosess for drosjeløyver
 weight: 70
 ---
 
+<script>
+    window.location.href = 'https://docs.data.altinn.no/tjenester/drosjeloyve/'
+</script>
+
+
 Søknad om drosjeløyve er en fylkeskommunal tjeneste i regi av Viken og FINT som ved bruk av samtykke automatisk henter inn deler av dokumentasjonskravet på vegne av søkende virksomhet.
 
 {{% evidencecodes Drosjeloyve %}}

--- a/content/utviklingsguider/data.altinn.no/tjenester/ebevis/_index.md
+++ b/content/utviklingsguider/data.altinn.no/tjenester/ebevis/_index.md
@@ -4,6 +4,11 @@ description: Informasjon om leverandører i offentlige anskaffelser
 weight: 1
 ---
 
+<script>
+    window.location.href = 'https://docs.data.altinn.no/tjenester/ebevis/'
+</script>
+
+
 eBevis er et samarbeid Brønnøysundregistrene, Skatteetaten, Digitaliseringsdirektoratet og DFØ. Løsningen ble produksjonsatt 01.04.19.
 
 eBevis er en løsning som er laget for å digitalisere anskaffelsesprosessen, og brukes samtidig som et verktøy for å kontrollere om leverandører er seriøse. eBevis lar offentlige oppdragsgivere/innkjøpere få tilgang til å hente inn definerte sanntidsdata om leverandører i forbindelse med offentlige anskaffelser. Det gjelder både før og etter kontraktinngåelse. 

--- a/content/utviklingsguider/data.altinn.no/tjenester/tilsynsdata/_index.md
+++ b/content/utviklingsguider/data.altinn.no/tjenester/tilsynsdata/_index.md
@@ -4,4 +4,8 @@ description: Deling av data mellom tilsynsmyndigheter
 weight: 100
 ---
 
+<script>
+    window.location.href = 'https://docs.data.altinn.no/tjenester/tilsynsdata/'
+</script>
+
 {{% evidencecodes Tilda %}}

--- a/content/utviklingsguider/data.altinn.no/tjenester/tilsynsdata/datakilder/_index.md
+++ b/content/utviklingsguider/data.altinn.no/tjenester/tilsynsdata/datakilder/_index.md
@@ -4,6 +4,10 @@ description: Standardisering av bakenforliggende apier
 weight: 100
 ---
 
+<script>
+    window.location.href = 'https://docs.data.altinn.no/tjenester/tilsynsdata/datakilder/'
+</script>
+
 
 {{% notice note %}}
 Under arbeid!

--- a/content/utviklingsguider/data.altinn.no/tjenester/tilsynsdata/eksempler/_index.md
+++ b/content/utviklingsguider/data.altinn.no/tjenester/tilsynsdata/eksempler/_index.md
@@ -4,6 +4,10 @@ description: Datamodeller
 weight: 100
 ---
 
+<script>
+    window.location.href = 'https://docs.data.altinn.no/tjenester/tilsynsdata/eksempler/'
+</script>
+
 *Under arbeid*
 
 Utkast til datamodeller

--- a/content/utviklingsguider/data.altinn.no/tjenester/tilsynsdata/eksempler/bekymringsmeldinger.md
+++ b/content/utviklingsguider/data.altinn.no/tjenester/tilsynsdata/eksempler/bekymringsmeldinger.md
@@ -4,6 +4,10 @@ description: Datamodell og schema
 weight: 100
 ---
 
+<script>
+    window.location.href = 'https://docs.data.altinn.no/tjenester/tilsynsdata/eksempler/bekymringsmeldinger/'
+</script>
+
 
 {{% notice note %}}
 Under arbeid!

--- a/content/utviklingsguider/data.altinn.no/tjenester/tilsynsdata/eksempler/enhetsinformasjon.md
+++ b/content/utviklingsguider/data.altinn.no/tjenester/tilsynsdata/eksempler/enhetsinformasjon.md
@@ -4,6 +4,10 @@ description: Datamodell og schema
 weight: 1
 ---
 
+<script>
+    window.location.href = 'https://docs.data.altinn.no/tjenester/tilsynsdata/eksempler/enhetsinformasjon/'
+</script>
+
 ### Eksempel
 
 ```json

--- a/content/utviklingsguider/data.altinn.no/tjenester/tilsynsdata/eksempler/klientrequest.md
+++ b/content/utviklingsguider/data.altinn.no/tjenester/tilsynsdata/eksempler/klientrequest.md
@@ -4,6 +4,10 @@ description: Eksempler på hvordan man henter data om en gitt virksomhet
 weight: 10
 ---
 
+<script>
+    window.location.href = 'https://docs.data.altinn.no/tjenester/tilsynsdata/eksempler/klientrequest/'
+</script>
+
 {{% notice note %}}
 Under arbeid!
 {{% /notice %}}

--- a/content/utviklingsguider/data.altinn.no/tjenester/tilsynsdata/eksempler/npdidtilsynsrapporter.md
+++ b/content/utviklingsguider/data.altinn.no/tjenester/tilsynsdata/eksempler/npdidtilsynsrapporter.md
@@ -4,6 +4,10 @@ description: Datamodell og schema
 weight: 10
 ---
 
+<script>
+    window.location.href = 'https://docs.data.altinn.no/tjenester/tilsynsdata/eksempler/npdidtilsynsrapporter/'
+</script>
+
 {{% notice note %}}
 Under arbeid!
 {{% /notice %}}

--- a/content/utviklingsguider/data.altinn.no/tjenester/tilsynsdata/eksempler/tilsynskoordineringer.md
+++ b/content/utviklingsguider/data.altinn.no/tjenester/tilsynsdata/eksempler/tilsynskoordineringer.md
@@ -4,6 +4,10 @@ description: Datamodell og schema
 weight: 2
 ---
 
+<script>
+    window.location.href = 'https://docs.data.altinn.no/tjenester/tilsynsdata/eksempler/tilsynskoordineringer/'
+</script>
+
 ### Eksempel
 ```json
 {

--- a/content/utviklingsguider/data.altinn.no/tjenester/tilsynsdata/eksempler/tilsynsrapporter.md
+++ b/content/utviklingsguider/data.altinn.no/tjenester/tilsynsdata/eksempler/tilsynsrapporter.md
@@ -4,6 +4,10 @@ description: Datamodell og schema
 weight: 3
 ---
 
+<script>
+    window.location.href = 'https://docs.data.altinn.no/tjenester/tilsynsdata/eksempler/tilsynsrapporter/'
+</script>
+
 ### Eksempel
 ```json
 {

--- a/content/utviklingsguider/data.altinn.no/tjenester/tilsynsdata/eksempler/trendrapporter.md
+++ b/content/utviklingsguider/data.altinn.no/tjenester/tilsynsdata/eksempler/trendrapporter.md
@@ -4,6 +4,10 @@ description: Datamodell og schema
 weight: 4
 ---
 
+<script>
+    window.location.href = 'https://docs.data.altinn.no/tjenester/tilsynsdata/eksempler/trendrapporter/'
+</script>
+
 ### Eksempel
 ```json
 {


### PR DESCRIPTION
DAN docs have been moved to [docs.data.altinn.no](https://docs.data.altinn.no/), added redirects to each DAN doc instead of deleting the old doc to maintain google ranking, etc.
