### PR TITLE
Fixed typo in subheader - Digital post

### DIFF
--- a/content/utviklingsguider/digital-post/_index.md
+++ b/content/utviklingsguider/digital-post/_index.md
@@ -13,7 +13,7 @@ Mottaker av en melding må alltid identifiserers ved hjelp av fødselsnummer ell
 
 Du kan lese mer om Meldingstjenesten [her](/docs/utviklingsguider/digital-post/om-tjenesten/)
 
-### For tjenesteeiere som benytter eFromidling eller KS svarut
+### For tjenesteeiere som benytter eFormidling eller KS svarut
 For virksomheter som benytter [Digdirs eFormidlingsløsning](https://samarbeid.digdir.no/eformidling/eformidling/20) finnes det en fellestjeneste posttjeneste i Altinn som benyttes. Les mer om hvordan du tar denne i bruk [her](/docs/utviklingsguider/digital-post-til-virksomheter/). 
 
 For virksomheter som benytter [KS sin Fiksplattform og SvarUt](https://www.ks.no/fagomrader/digitalisering/felleslosninger/fiks-plattformen/tjenster-pa-fiks-plattformen/) for å sende meldinger så finnes tilsvarende fellespostjeneste i Altinn. Informasjon om dette finner du på KS sin dokumentasjon av [tjenesten](https://developers.fiks.ks.no/tjenester/svarut/). 


### PR DESCRIPTION
Fixed typo in subheader


## Description
Fromidling is spelled formidling

## Related Issue(s)
- #{issue number}

## Verification
only changed an *.md file, no build or tests required

## Documentation
- [ ] User documentation is updated with a separate linked PR in [altinn-studio-docs.](https://github.com/Altinn/altinn-studio-docs) (if applicable)
