### PR TITLE
Rename slack

### DIFF
--- a/layouts/partials/footer-content.html
+++ b/layouts/partials/footer-content.html
@@ -18,7 +18,7 @@
                             </a>
                         </li>
                         <li>
-                            <a href="https://altinn.slack.com/">
+                            <a href="https://digdir-samarbeid.slack.com/">
                                 <i class="fa fa-slack" aria-hidden="true"></i>
                                 <span>Slack</span>
                             </a>


### PR DESCRIPTION
Rename from altinn.slack.com to https://digdir-samarbeid.slack.com